### PR TITLE
Allow to unbind onload/onerror callback handlers

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -276,6 +276,12 @@ NAN_SETTER(Image::SetOnload) {
   if (value->IsFunction()) {
     Image *img = ObjectWrap::Unwrap<Image>(args.This());
     img->onload = new NanCallback(value.As<Function>());
+  } else if (value->IsNull()) {
+    Image *img = ObjectWrap::Unwrap<Image>(args.This());
+    if (img->onload) {
+      delete img->onload;
+    }
+    img->onload = NULL;
   }
 }
 
@@ -301,6 +307,12 @@ NAN_SETTER(Image::SetOnerror) {
   if (value->IsFunction()) {
     Image *img = ObjectWrap::Unwrap<Image>(args.This());
     img->onerror = new NanCallback(value.As<Function>());
+  } else if (value->IsNull()) {
+    Image *img = ObjectWrap::Unwrap<Image>(args.This());
+    if (img->onerror) {
+        delete img->onerror;
+    }
+    img->onerror = NULL;
   }
 }
 

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -7,6 +7,7 @@ var Canvas = require('../')
   , Image = Canvas.Image
   , assert = require('assert');
 
+var png_checkers = __dirname + '/fixtures/checkers.png';
 var png = __dirname + '/fixtures/clock.png';
 
 module.exports = {
@@ -86,5 +87,57 @@ module.exports = {
     var image = new Canvas.Image();
     image.src = new Buffer(0);
     image.src = new Buffer('');
+  },
+
+  'test unbind Image#onload': function() {
+    var img = new Image
+      , n = 0;
+
+    img.onload = function() {
+      ++n;
+    };
+
+    img.src = png_checkers;
+    assert.equal(img.src, png_checkers);
+    assert.strictEqual(true, img.complete);
+    assert.strictEqual(2, img.width);
+    assert.strictEqual(2, img.height);
+
+    assert.equal(n, 1);
+
+    n = 0;
+    img.onload = null;
+    img.src = png;
+    assert.equal(img.src, png);
+    assert.strictEqual(true, img.complete);
+    assert.strictEqual(320, img.width);
+    assert.strictEqual(320, img.height);
+
+    assert.equal(n, 0);
+  },
+
+  'test unbind Image#onerror': function() {
+    var img = new Image
+      , n = 0;
+
+
+    img.onload = function() {
+      assert.fail('called onload');
+    };
+
+    img.onerror = function() {
+      ++n;
+    };
+
+    img.src = png + 's1';
+    assert.equal(img.src, png + 's1');
+
+    assert.equal(n, 1);
+
+    n = 0;
+    img.onerror = null;
+    img.src = png + 's3';
+    assert.equal(img.src, png + 's3');
+    assert.equal(n, 0);
   }
 };


### PR DESCRIPTION
Assigning `null` to handlers removes them, this mimic the behaviour from Google Chrome.

From Chrome's Developer Tools:

``` js
> function handler(evt) { console.log('img handler: %s', evt.type); }
< undefined
> var img = document.createElement('img')
< undefined
> img.onload = handler
< handler(evt)
> img.onerror = handler
< handler(evt)
> img.src = 'https://www.google.com/images/errors/logo_sm_2.png'; true
< true
< img handler: load
> img.src = 'https://www.google.com/images/errors/logo_sm_2.png'; true
< true
< img handler: load
> img.src = 'https://example.com/404.png'; true
< true
< img handler: error
> img.src = 'https://example.com/404.png'; true
< true
< img handler: error
> img.onload = null
< null
> img.onerror = null
< null
> img.src = 'https://www.google.com/images/errors/logo_sm_2.png'; true
< true
> img.src = 'https://example.com/404.png'; true
< true
```
