### PR TITLE
Allow to set src=null to clear data

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -184,6 +184,8 @@ NAN_SETTER(Image::SetSource) {
     uint8_t *buf = (uint8_t *) Buffer::Data(value->ToObject());
     unsigned len = Buffer::Length(value->ToObject());
     status = img->loadFromBuffer(buf, len);
+  } else if (value->IsNull()) {
+    status = CAIRO_STATUS_INVALID_CONTENT;
   }
 
   // check status

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -35,6 +35,29 @@ module.exports = {
     assert.strictEqual(320, img.height);
     assert.equal(1, n);
   },
+
+  'test Image#onerror src=null': function() {
+    var img = new Image
+      , n = 0
+      , error;
+
+
+    img.onload = function() {
+      assert.fail('called onload');
+    };
+
+    img.onerror = function(err) {
+      error = err;
+      ++n;
+    };
+
+    img.src = null;
+
+    assert.ok(error instanceof Error, 'did not invoke onerror() with error');
+    assert.strictEqual(error.message, 'invalid value for an input cairo_content_t');
+    assert.strictEqual(img.complete, false);
+    assert.equal(n, 1);
+  },
   
   'test Image#onerror': function(){
     var img = new Image


### PR DESCRIPTION
This still invokes onerror callback if binded, which is usual browser behaviour.

Error is specific for this case, using `CAIRO_STATUS_INVALID_CONTENT`.
Not sure if error should be `CAIRO_STATUS_NULL_POINTER` instead.

From Chrome's Developer Tools:

``` js
> var img = document.createElement('img')
< undefined
> img.onerror = function handler(evt) { console.log('img onload/onerror handler: %s', evt.type); }
< handler(evt)
> img.src = null
< null
< img onload/onerror handler: error
```
